### PR TITLE
fix port unavailability in startup script

### DIFF
--- a/start-up.sh
+++ b/start-up.sh
@@ -1,5 +1,23 @@
 #!/bin/sh
 
+declare -a PortsArray=("61616" "8161" "8761" "3306" "9042")
+
+echo "These ports ${PortsArray[@]} are required to continue:"
+read -ep "Do you want to stop any processes using these ports? [y/N] " yesno
+case $yesno in
+    [Yy]* )
+        for port in ${PortsArray[*]}; do
+          running_process=`lsof -t -i :$port`
+          if [ -n "$running_process" ]
+          then
+            for i in $running_process; do kill $i; done
+            echo "Process on $port has been stopped"
+          fi
+        done
+    *)
+          echo "Skipping"
+          break;;
+esac
 echo "Create service network"
 docker network create --driver=bridge --subnet=172.16.238.0/24 externaltools_app_net
 


### PR DESCRIPTION
This PR is submitted in relation to this issue: Unavailable ports causes startup script to hang indefinitely #11

Now, a typical User is now prompted with an option to stop processes using ports that might conflict during provisioning fineract micro-services.


Good first PR :)
